### PR TITLE
Enable redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -16,3 +16,7 @@ safe: true
 lsi: false
 highlighter: pygments
 source: .
+
+gems:
+  - jekyll-redirect-from
+

--- a/blog/_posts/2013-06-03-introducing-nupic.md
+++ b/blog/_posts/2013-06-03-introducing-nupic.md
@@ -2,9 +2,7 @@
 layout: blogpost
 title: Introducing NuPIC
 category: blog
-redirect_from:
-    - /news/2013/06/03/introducing-nupic.html
-    - /foo
+redirect_from: "/news/2013/06/03/introducing-nupic.html"
 ---
 
 Welcome to the NuPIC open source project.  This is a good place to be if you are interested in machine intelligence and brain modeling.

--- a/blog/_posts/2013-06-03-introducing-nupic.md
+++ b/blog/_posts/2013-06-03-introducing-nupic.md
@@ -2,6 +2,9 @@
 layout: blogpost
 title: Introducing NuPIC
 category: blog
+redirect_from:
+    - /news/2013/06/03/introducing-nupic.html
+    - /foo
 ---
 
 Welcome to the NuPIC open source project.  This is a good place to be if you are interested in machine intelligence and brain modeling.

--- a/blog/_posts/2013-06-10-hackathon-june-2013.md
+++ b/blog/_posts/2013-06-10-hackathon-june-2013.md
@@ -2,6 +2,7 @@
 layout: blogpost
 title: First NuPIC Hackathon
 category: blog
+redirect_from: "/news/2013/06/10/hackathon-june-2013.html"
 ---
 
 We're having a NuPIC Hackathon on June 21, and we have about five spaces available for more participants. *First come, first served!* It will be in the San Francisco Bay Area. If you are interested in attending, please contact me directly at <matt@numenta.org>.

--- a/blog/_posts/2013-06-25-hackathon-outcome.md
+++ b/blog/_posts/2013-06-25-hackathon-outcome.md
@@ -2,6 +2,7 @@
 layout: blogpost
 title: Hackathon Outcome
 category: blog
+redirect_from: "/news/2013/06/25/hackathon-outcome.html"
 ---
 
 The first NuPIC Hackathon occurred over the past weekend, ending with eight demo applications from ten different participants. Even though there were some struggles getting NuPIC building and running on different platforms (we anticipated that), I consider this event a success based on the number of demonstrations ready within 24 hours.

--- a/blog/_posts/2013-07-01-patent-position.md
+++ b/blog/_posts/2013-07-01-patent-position.md
@@ -2,6 +2,7 @@
 layout: blogpost
 title: Patent Position
 category: blog
+redirect_from: "/news/2013/07/01/patent-position.html"
 ---
 
 It’s been exciting to see the early positive reaction to our NuPIC open source project (Numenta Platform for Intelligent Computing).  As part of the team that helped start this project, I’m optimistic that great work will come out of it over time.

--- a/blog/_posts/2013-07-09-predicting-movement-with-ir-sensors.md
+++ b/blog/_posts/2013-07-09-predicting-movement-with-ir-sensors.md
@@ -3,6 +3,7 @@ layout: blogpost
 title: Predicting Movement with IR Sensors
 guest: Erik Blas
 category: blog
+redirect_from: "/news/2013/07/09/predicting-movement-with-ir-sensors.html"
 ---
 
 ### My Experience at the First NuPIC Hackathon

--- a/blog/_posts/2013-08-13-brains-and-machine-intelligence-a-long-time-coming.md
+++ b/blog/_posts/2013-08-13-brains-and-machine-intelligence-a-long-time-coming.md
@@ -2,6 +2,7 @@
 layout: blogpost
 title: Brains and Machine Intelligence, A Long Time Coming
 category: blog
+redirect_from: "/news/2013/08/13/brains-and-machine-intelligence-a-long-time-coming.html"
 ---
 
 Recently one of our U.S. agencies, the IARPA (Intelligence Advanced Research Projects Activity), put out an RFI (request for information) stating they are interested in machine learning algorithms that are based on neuroanatomy.  Although this RFI is only a few weeks old, I feel like I have been waiting for it for thirty years.

--- a/news/2013/06/03/introducing-nupic.html
+++ b/news/2013/06/03/introducing-nupic.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: News Item Redirect
----
-
-<script lang="javascript">
-    window.location = '{{ site.baseurl }}/blog/2013/06/03/introducing-nupic.html';
-</script>

--- a/news/2013/06/10/hackathon-june-2013.html
+++ b/news/2013/06/10/hackathon-june-2013.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: News Item Redirect
----
-
-<script lang="javascript">
-    window.location = '{{ site.baseurl }}/blog/2013/06/10/hackathon-june-2013.html';
-</script>

--- a/news/2013/06/25/hackathon-outcome.md
+++ b/news/2013/06/25/hackathon-outcome.md
@@ -1,8 +1,0 @@
----
-layout: default
-title: News Item Redirect
----
-
-<script lang="javascript">
-    window.location = '{{ site.baseurl }}/blog/2013/06/25/hackathon-outcome.html';
-</script>

--- a/news/2013/07/01/patent-position.html
+++ b/news/2013/07/01/patent-position.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: News Item Redirect
----
-
-<script lang="javascript">
-    window.location = '{{ site.baseurl }}/blog/2013/07/01/patent-position.html';
-</script>

--- a/news/2013/07/09/predicting-movement-with-ir-sensors.html
+++ b/news/2013/07/09/predicting-movement-with-ir-sensors.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: News Item Redirect
----
-
-<script lang="javascript">
-    window.location = '{{ site.baseurl }}/blog/2013/07/09/predicting-movement-with-ir-sensors.html';
-</script>

--- a/news/2013/08/13/brains-and-machine-intelligence-a-long-time-coming.html
+++ b/news/2013/08/13/brains-and-machine-intelligence-a-long-time-coming.html
@@ -1,8 +1,0 @@
----
-layout: default
-title: News Item Redirect
----
-
-<script lang="javascript">
-    window.location = '{{ site.baseurl }}/blog/2013/08/13/brains-and-machine-intelligence-a-long-time-coming.html';
-</script>

--- a/news/2013/README.md
+++ b/news/2013/README.md
@@ -1,3 +1,0 @@
-# Redirects
-
-These files and folders are here to provide redirects from old URLs to new ones. Before the blog was split into 'news' and 'blog' sections, there was only a 'news' section. To preserve old URLs that are already linked to from many places on the internet, they are preserved here with a JavaScript script to change to the proper location.


### PR DESCRIPTION
Using Jekyll redirect plugin for old "news" posts that were converted into blog posts instead of a client-side JavaScript redirect. 