### PR TITLE
NAB competition page fixes from Christy.

### DIFF
--- a/_sass/_nab.scss
+++ b/_sass/_nab.scss
@@ -5,9 +5,30 @@
     ul {
         li {
             list-style: disc;
+            ul li {
+                list-style: circle;
+            }
         }
     }
     ul.toc li {
         list-style: none;
+    }
+    h1 {
+        small {
+            color: black;
+        }
+    }
+    h3 {
+        color: #555;
+    }
+    h4 {
+        color: #888;
+    }
+    h3:before, h4:before {
+        display: block; 
+        content: " "; 
+        margin-top: -110px; 
+        height: 110px; 
+        visibility: hidden; 
     }
 }

--- a/nab/index.html
+++ b/nab/index.html
@@ -8,7 +8,7 @@ styles:
 <section id="nab-competition">
 
     <h1>
-        The Numenta Anomaly Benchmark Competition For Real Time <br/>
+        The Numenta Anomaly Benchmark Competition For Real Time Anomaly Detection<br/>
         <small><em>Part of the</em> <a target="_blank" href="http://www.wcci2016.org/programs.php?id=home">IEEE WCCI</a> (World Congress on Computational Intelligence)</small>
     </h1>
 
@@ -41,7 +41,7 @@ styles:
 
     <h3 id="what-is-the-nab-competition">What is the NAB competition?</h3>
 
-    <p/>We are conducting this competition in association with the IEEE WCCI (World Congress on Computational Intelligence). The WCCI NAB competition has two categories:
+    <p/><a href="http://numenta.com" target="_blank">Numenta</a> is conducting this competition in association with the IEEE WCCI (World Congress on Computational Intelligence). The WCCI NAB competition has two categories:
 
     <ol>
         <li>Algorithms: what is the best algorithm for detecting anomalies in streaming data?</li>
@@ -50,7 +50,7 @@ styles:
 
     <h3 id="how-do-i-enter">How do I enter?</h3>
 
-    <p/>You may submit to either the algorithms or datasets components, or both.
+    <p/>You may submit to either the algorithms or datasets components, or both. Please send all submissions to <a href="mailto:nab@numenta.org">nab@numenta.org</a>.
 
     <h4 id="algorithms-category">Algorithms Category</h4>
 

--- a/node_modules/jquery.universal-analytics/package.json
+++ b/node_modules/jquery.universal-analytics/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/tomfuertes/jquery-universal-analytics/issues"
   },
   "_id": "jquery.universal-analytics@0.0.7",
-  "_shasum": "a19f6dfd0b07637411bca4134cca6468840d14d9",
+  "_shasum": "b3571d4395919431e1a31918e682fe031dc2d385",
   "_from": "tomfuertes/jquery-universal-analytics#4623a42a5472af565e6b44513ab5c29e94946093",
   "_resolved": "git://github.com/tomfuertes/jquery-universal-analytics.git#4623a42a5472af565e6b44513ab5c29e94946093"
 }

--- a/node_modules/retina.js/package.json
+++ b/node_modules/retina.js/package.json
@@ -22,7 +22,7 @@
   "readmeFilename": "README.md",
   "description": "### JavaScript, LESS and SASS helpers for rendering high-resolution image variants",
   "_id": "retina.js@1.3.0",
-  "_shasum": "6f53919ce21ce8310d97c43db9246b6983c04c11",
+  "_shasum": "1cb475aa9de28a678dd34bd85a02963805b51d8f",
   "_from": "imulus/retinajs#c528fe9359b4b97f507617440c1a7d6c3d2b31df",
   "_resolved": "git://github.com/imulus/retinajs.git#c528fe9359b4b97f507617440c1a7d6c3d2b31df"
 }

--- a/sitemap/sitemap.xml
+++ b/sitemap/sitemap.xml
@@ -9,11 +9,11 @@
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
-        <loc>http://numenta.org/committers/</loc>
+        <loc>http://numenta.org/blog/</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
-        <loc>http://numenta.org/blog/</loc>
+        <loc>http://numenta.org/committers/</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
@@ -25,11 +25,11 @@
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
-        <loc>http://numenta.org/faq/</loc>
+        <loc>http://numenta.org/events/</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
-        <loc>http://numenta.org/events/</loc>
+        <loc>http://numenta.org/faq/</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
@@ -50,7 +50,7 @@
     </url>
     <url>
         <loc>http://numenta.org/nab/</loc>
-        <lastmod>2016-01-27T21:36:23.000Z</lastmod>
+        <lastmod>2016-01-28T17:41:05.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/news/</loc>
@@ -74,47 +74,47 @@
     </url>
     <url>
         <loc>http://numenta.org/styleguide/</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-1.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-10.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-2.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-3.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-4.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-5.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-6.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-7.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-8.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/styleguide/section-9.html</loc>
-        <lastmod>2016-01-27T21:36:36.000Z</lastmod>
+        <lastmod>2016-01-28T17:42:09.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/allclasses-frame.html</loc>
@@ -2985,12 +2985,12 @@
         <lastmod>2014-12-10T04:54:01.000Z</lastmod>
     </url>
     <url>
-        <loc>http://numenta.org/events/hackathon/2013/jun/messages.html</loc>
-        <lastmod>2015-06-08T02:40:08.000Z</lastmod>
-    </url>
-    <url>
         <loc>http://numenta.org/events/hackathon/2013/nov/</loc>
         <lastmod>2014-04-11T16:30:19.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/events/hackathon/2013/jun/messages.html</loc>
+        <lastmod>2015-06-08T02:40:08.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/events/hackathon/2014/may/</loc>
@@ -3003,10 +3003,6 @@
     <url>
         <loc>http://numenta.org/events/hackathon/2015/may/</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/events/hackathon/2013/jun/slides/</loc>
-        <lastmod>2015-06-08T02:40:08.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/ComputeCycle.html</loc>
@@ -3081,6 +3077,10 @@
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
+        <loc>http://numenta.org/events/hackathon/2013/jun/slides/</loc>
+        <lastmod>2015-06-08T02:40:08.000Z</lastmod>
+    </url>
+    <url>
         <loc>http://numenta.org/events/hackathon/2014/may/hack/</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
@@ -3142,98 +3142,6 @@
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/benchmarks/package-use.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ComputeCycle.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Connections.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ConnectionsTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/FieldMetaType.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Parameters.KEY.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Parameters.ParametersMap.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Parameters.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ParametersTest.DummyContainer.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ParametersTest.DummyContainerBase.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ParametersTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/SDR.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/SDRTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ValueList.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/ConsecutivePatternMachine.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/PatternMachine.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/ResourceLocator.Resource.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/ResourceLocator.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/SequenceMachine.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/SequenceMachineTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-frame.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-summary.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-tree.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-use.html</loc>
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
     </url>
     <url>
@@ -3371,6 +3279,150 @@
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/algorithms/package-use.html</loc>
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ComputeCycle.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Connections.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ConnectionsTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/FieldMetaType.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Parameters.KEY.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Parameters.ParametersMap.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/Parameters.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ParametersTest.DummyContainer.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ParametersTest.DummyContainerBase.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ParametersTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/SDR.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/SDRTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/class-use/ValueList.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/ConsecutivePatternMachine.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/PatternMachine.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/ResourceLocator.Resource.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/ResourceLocator.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/SequenceMachine.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/SequenceMachineTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-frame.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-summary.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-tree.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/package-use.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/AbstractTemporalMemoryTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/BasicTemporalMemoryTest.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/ExtensiveTemporalMemoryTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/TemporalMemoryTestMachine.DetailedResults.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/TemporalMemoryTestMachine.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-frame.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-summary.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-tree.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-use.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-frame.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-summary.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-tree.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-use.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/encoders/AdaptiveScalarEncoder.Builder.html</loc>
@@ -3582,58 +3634,6 @@
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/encoders/package-use.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-frame.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-summary.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-tree.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/package-use.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/AbstractTemporalMemoryTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/BasicTemporalMemoryTest.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/ExtensiveTemporalMemoryTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/TemporalMemoryTestMachine.DetailedResults.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/TemporalMemoryTestMachine.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-frame.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-summary.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-tree.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/package-use.html</loc>
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
     </url>
     <url>
@@ -4069,30 +4069,6 @@
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
     </url>
     <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/ConsecutivePatternMachine.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/PatternMachine.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/ResourceLocator.Resource.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/ResourceLocator.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/SequenceMachine.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/SequenceMachineTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/algorithms/class-use/Anomaly.AveragedAnomalyRecordList.html</loc>
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
     </url>
@@ -4211,6 +4187,146 @@
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/algorithms/class-use/TemporalMemoryTest.html</loc>
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/ConsecutivePatternMachine.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/PatternMachine.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/ResourceLocator.Resource.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/ResourceLocator.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/SequenceMachine.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/datagen/class-use/SequenceMachineTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/AbstractTemporalMemoryTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/BasicTemporalMemoryTest.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/ExtensiveTemporalMemoryTest.html</loc>
+        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/TemporalMemoryTestMachine.DetailedResults.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/TemporalMemoryTestMachine.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-frame.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-summary.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-tree.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-use.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/NetworkAPIDemo.Mode.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/NetworkAPIDemo.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/NetworkDemoHarness.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-frame.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-summary.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-tree.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-use.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTest.Layer.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTest.LayerImpl.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTest.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTestTest.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-frame.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-summary.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-tree.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-use.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/HelloSP.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-frame.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-summary.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-tree.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-use.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/encoders/class-use/AdaptiveScalarEncoder.Builder.html</loc>
@@ -4407,122 +4523,6 @@
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/encoders/class-use/SparsePassThroughEncoderTest.html</loc>
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-frame.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-summary.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-tree.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/package-use.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/NetworkAPIDemo.Mode.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/NetworkAPIDemo.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/NetworkDemoHarness.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-frame.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-summary.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-tree.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/network/package-use.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTest.Layer.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTest.LayerImpl.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTest.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/QuickTestTest.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-frame.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-summary.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-tree.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/qt/package-use.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/HelloSP.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-frame.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-summary.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-tree.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/sp/package-use.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/AbstractTemporalMemoryTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/BasicTemporalMemoryTest.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/ExtensiveTemporalMemoryTest.html</loc>
-        <lastmod>2016-01-27T20:54:02.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/TemporalMemoryTestMachine.DetailedResults.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/integration/class-use/TemporalMemoryTestMachine.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/monitor/class-use/ComputeDecorator.html</loc>
@@ -5061,6 +5061,34 @@
         <lastmod>2016-01-27T20:54:02.000Z</lastmod>
     </url>
     <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/FoxEatsDemo.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/FoxEatsDemoTest.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/FoxEatsDemoView.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-frame.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-summary.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-tree.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-use.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/breakingnews/BreakingNewsDemo.html</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
@@ -5098,34 +5126,6 @@
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/breakingnews/package-use.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/FoxEatsDemo.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/FoxEatsDemoTest.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/FoxEatsDemoView.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-frame.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-summary.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-tree.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/package-use.html</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>
@@ -5341,6 +5341,18 @@
         <lastmod>2015-06-08T02:40:08.000Z</lastmod>
     </url>
     <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/class-use/FoxEatsDemo.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/class-use/FoxEatsDemoTest.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
+        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/class-use/FoxEatsDemoView.html</loc>
+        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
+    </url>
+    <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/breakingnews/class-use/BreakingNewsDemo.html</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
@@ -5362,18 +5374,6 @@
     </url>
     <url>
         <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/breakingnews/class-use/StrictHackathonAlgorithm.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/class-use/FoxEatsDemo.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/class-use/FoxEatsDemoTest.html</loc>
-        <lastmod>2015-08-11T19:21:57.000Z</lastmod>
-    </url>
-    <url>
-        <loc>http://numenta.org/docs/htm.java/org/numenta/nupic/examples/cortical_io/foxeats/class-use/FoxEatsDemoView.html</loc>
         <lastmod>2015-08-11T19:21:57.000Z</lastmod>
     </url>
     <url>


### PR DESCRIPTION
- Title is missing the second line.  The full title is: The Numenta Anomaly Benchmark Competition For Real-Time Anomaly Detection
- The gray subtitle text is hard to read, can you change that to black?
- Each of the hyperlinks in the TOC jumps to the section following the one referenced in the hyperlink.  I don’t’ know if that’s just on my browser or on PC laptop for example.
- In the section What is the NAB competition?, can you change the first sentence from: “We are conducting” to “Numenta is conducting” and hyperlink Numenta to Numenta.com?
- In the section How do I enter?, can you add this sentence after the first sentence: Please send all submissions to nab@numenta.org.
- In sections when there are two levels of bullets, can you do a different style to distinguish between the levels?
- I find the color of the text of the subheaders easier to read than the color of the headers text.  Example below.  Can you switch the colors but keep the sizes? 